### PR TITLE
Logging module updates.

### DIFF
--- a/ush/python/pygw/src/pygw/logger.py
+++ b/ush/python/pygw/src/pygw/logger.py
@@ -1,28 +1,108 @@
 """
-Logger
+Module
+------
+
+    pygw.logger (pygw/src/pygw/logger.py)
+
+Description
+-----------
+
+    This module contains the base-class object for all Logger
+    instances.
+
+Classes
+-------
+
+    ColoredFormatter(fmt)
+
+        This is the base-class object for all logger object color
+        formatting as a function logging level; it is a sub-class of
+        logging.Formatter.
+
+    Logger(name=None, level=None, _format=None, colored_log=False,
+           logfile_path=None)
+
+        This is the base-class object for all Logger object instances.
+
+Functions
+---------
+
+    logit(logger, name= None, message= None)
+
+        This function provides a decorator to be used for adding
+        logging to a module, class, method, or function.
+
 """
 
+# ----
+
+__version__ = 1.0
+
+# ----
+
+import logging
+import os
 import sys
+from dataclasses import dataclass
 from functools import wraps
 from pathlib import Path
-from typing import Union, List
-import logging
+from typing import Callable, List, Union
+
+# ----
 
 
 class ColoredFormatter(logging.Formatter):
     """
-    Logging colored formatter
-    adapted from https://stackoverflow.com/a/56944256/3638629
+    Description
+    -----------
+
+    This is the base-class object for all logger object color
+    formatting as a function logging level; it is a sub-class of
+    logging.Formatter.
+
+    Parameters
+    ----------
+
+    fmt: str
+
+        A Python string defining the logging format.
+
+    Returns
+    -------
+
+    formatter: object
+
+        A Python object containing the format attributes for the
+        logger object.
+
+    Notes
+    -----
+
+    The methodology for this method has been collected from the
+    following sources.
+
+    - https://stackoverflow.com/a/56944256/3638629
+
     """
 
-    grey = '\x1b[38;21m'
-    blue = '\x1b[38;5;39m'
-    yellow = '\x1b[38;5;226m'
-    red = '\x1b[38;5;196m'
-    bold_red = '\x1b[31;1m'
-    reset = '\x1b[0m'
+    # Define the colors available for the Formatter object.
+    grey = "\x1b[38;21m"
+    blue = "\x1b[38;5;39m"
+    yellow = "\x1b[38;5;226m"
+    red = "\x1b[38;5;196m"
+    bold_red = "\x1b[31;1m"
+    reset = "\x1b[0m"
 
     def __init__(self, fmt):
+        """
+        Description
+        -----------
+
+        Creates a new ColoredFormatter object.
+
+        """
+
+        # Define the base-class attributes.
         super().__init__()
         self.fmt = fmt
         self.formats = {
@@ -30,67 +110,136 @@ class ColoredFormatter(logging.Formatter):
             logging.INFO: self.grey + self.fmt + self.reset,
             logging.WARNING: self.yellow + self.fmt + self.reset,
             logging.ERROR: self.red + self.fmt + self.reset,
-            logging.CRITICAL: self.bold_red + self.fmt + self.reset
+            logging.CRITICAL: self.bold_red + self.fmt + self.reset,
         }
 
     def format(self, record):
+        """
+        Description
+        -----------
+
+        This method defines and returns the logging object formatting
+        attribute(s).
+
+        Returns
+        -------
+
+        formatter: object
+
+            A Python object containing the logging object formatting
+            attributes.
+
+        """
+
+        # Define the logging object formatting attributes.
         log_fmt = self.formats.get(record.levelno)
-        formatter = logging.Formatter(log_fmt)
-        return formatter.format(record)
+        formatter = logging.Formatter(log_fmt).format(record)
+
+        return formatter
 
 
+# ----
+
+
+@dataclass
 class Logger:
     """
-    Improved logging
+    Description
+    -----------
+
+    This is the base-class object for all Logger object instances.
+
+    Keywords
+    --------
+
+    name: str, optional
+
+        A Python object specifying the name for the respective Logger
+        object.
+
+    level: str, optional
+
+        A Python string specifying the logging level for the
+        respective Logger object; if NoneType upon entry, the run-time
+        environment will be queried for the attribute `LOGGING_LEVEL`;
+        if NoneTypee, the default value "INFO" will be assigned.
+
+    _format: str, optional
+
+        A Python string specifying the desired logging format; if
+        NoneType upon entry the value for defined by the base-class
+        attribute `DEFAULT_FORMAT` will be assigned.
+
+    colored_log: bool, optional
+
+        A Python boolean valued variable specifying whether to use the
+        color attributes, defined within in the `ColoredFormatter`
+        object, for the logging messages.
+
+    logfile_path: Union[str, Path], optional
+
+        A Python string or Path object defining the output filepath to
+        which the logging information is to be written.
+
+    Raises
+    ------
+
+    LookupError:
+
+        - raised if the specified logging level is not supported.
+
     """
-    LOG_LEVELS = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
-    DEFAULT_LEVEL = 'INFO'
-    DEFAULT_FORMAT = '%(asctime)s - %(levelname)-8s - %(name)-12s: %(message)s'
 
-    def __init__(self, name: str = None,
-                 level: str = DEFAULT_LEVEL,
-                 _format: str = DEFAULT_FORMAT,
-                 colored_log: bool = False,
-                 logfile_path: Union[str, Path] = None):
+    # Define the supported (e.g., default) logging attributes.
+    LOG_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+
+    DEFAULT_LEVEL = "INFO"
+
+    DEFAULT_FORMAT = "%(asctime)s - %(levelname)-8s - %(name)-12s: %(message)s"
+
+    def __init__(
+        self: object,
+        name: str = None,
+        level: str = None,
+        _format: str = DEFAULT_FORMAT,
+        colored_log: bool = False,
+        logfile_path: Union[str, Path] = None,
+    ):
         """
-        Initialize Logger
+        Description
+        -----------
 
-        Parameters
-        ----------
-        name         : str
-                       Name of the Logger object
-                       default : None
-        level        : str
-                       Desired Logging level
-                       default : 'INFO'
-        _format      : str
-                       Desired Logging Format
-                       default : '%(asctime)s - %(levelname)-8s - %(name)-12s: %(message)s'
-        colored_log  : bool
-                       Use colored logging for stdout
-                       default: False
-        logfile_path : str or Path
-                       Path for logging to a file
-                       default : None
+        Creates a new Logger object.
+
         """
 
+        # Define the base-class attributes.
         self.name = name
-        self.level = level.upper()
+        self.level = level
         self.format = _format
         self.colored_log = colored_log
 
+        # Define the logger object attributes; proceed accordingly.
+        if level is None:
+            level = os.environ.get("LOGGING_LEVEL")
+
+            if level is None:
+                level = Logger.DEFAULT_LEVEL
+
+        self.level = level.upper()
+
         if self.level not in Logger.LOG_LEVELS:
-            raise LookupError('{self.level} is unknown logging level\n' +
-                              'Currently supported log levels are:\n' +
-                              f'{" | ".join(Logger.LOG_LEVELS)}')
+            raise LookupError(
+                f"{self.level} is an unknown logging level; "
+                + f'Currently supported log levels are {", ".join(Logger.LOG_LEVELS)}'
+            )
 
-        # Initialize the root logger if no name is present
         self._logger = logging.getLogger(name) if name else logging.getLogger()
-
         self._logger.setLevel(self.level)
 
+        # Define the console handler for the logging object.
         _handlers = []
-        # Add console handler for logger
+
         _handler = Logger.add_stream_handler(
             level=self.level,
             _format=self.format,
@@ -99,122 +248,127 @@ class Logger:
         _handlers.append(_handler)
         self._logger.addHandler(_handler)
 
-        # Add file handler for logger
+        # Define the file handler for the logging object (if
+        # applicable).
         if logfile_path is not None:
-            _handler = Logger.add_file_handler(logfile_path, level=self.level, _format=self.format)
+            _handler = Logger.add_file_handler(
+                logfile_path, level=self.level, _format=self.format
+            )
             self._logger.addHandler(_handler)
             _handlers.append(_handler)
 
-    def __getattr__(self, attribute):
+    def __getattr__(self: object, attribute: str) -> Union[str, int, float, bool]:
         """
-        Allows calling logging module methods directly
+        Description
+        -----------
+
+        This method allows the calling logging module methods
+        directly.
 
         Parameters
         ----------
+
+        attribute: str
+
+            A Python object specifying the attribute name for the
+            logging object.
+
+        Returns
+        -------
+
         attribute : str
-                    attribute name of a logging object
 
-        Returns
-        -------
-        attribute : logging attribute
-        """
-        return getattr(self._logger, attribute)
+            A Python string defining the value for the specified
+            attribute.
 
-    def get_logger(self):
         """
-        Return the logging object
 
-        Returns
-        -------
-        logger : Logger object
-        """
-        return self._logger
+        # Collect the attribute specified upon entry from the logger
+        # object.
+        logger_attr = getattr(self._logger, attribute)
+
+        return logger_attr
 
     @classmethod
-    def add_handlers(cls, logger: logging.Logger, handlers: List[logging.Handler]):
+    def add_handlers(
+        cls: object, logger: logging.Logger, handlers: List[logging.Handler]
+    ) -> logging.Logger:
         """
-        Add a list of handlers to a logger
+        Description
+        -----------
+
+        This method adds a list of handlers to a logging object.
 
         Parameters
         ----------
-        logger : logging.Logger
-                 Logger object to add a new handler to
-        handlers: list
-                 A list of handlers to be added to the logger object
+
+        logger: logging.Logger
+
+            A Python logging library Logger object to which a new
+            handler is to be added.
+
+        handlers: List
+
+            A Python list of supported handlers to be added to the
+            logger object.
 
         Returns
         -------
-        logger : Logger object
+
+        logger: logging.logger
+
+            A Python logging library Logger object containing the
+            specified (supported) logging handler attributes.
+
         """
+
+        # Update the logging object with the respective (supported)
+        # logging handlers.
         for handler in handlers:
             logger.addHandler(handler)
 
         return logger
 
     @classmethod
-    def add_stream_handler(cls, level: str = DEFAULT_LEVEL,
-                           _format: str = DEFAULT_FORMAT,
-                           colored_log: bool = False):
+    def add_file_handler(
+        cls: object, logfile_path: Union[str, Path], level: str, _format: str
+    ) -> logging.Handler:
         """
-        Create stream handler
-        This classmethod will allow setting a custom stream handler on children
+        Description
+        -----------
+
+        This method allows the setting of custom file handlers for
+        caller modules.
 
         Parameters
         ----------
-        level : str
-                logging level
-                default : 'INFO'
-        _format : str
-                  logging format
-                  default : '%(asctime)s - %(levelname)-8s - %(name)-12s: %(message)s'
-        colored_log : bool
-                      enable colored output for stdout
-                      default : False
 
-        Returns
-        -------
-        handler : logging.Handler
-                  stream handler of a logging object
-        """
-
-        handler = logging.StreamHandler(sys.stdout)
-        handler.setLevel(level)
-        _format = ColoredFormatter(_format) if colored_log else logging.Formatter(_format)
-        handler.setFormatter(_format)
-
-        return handler
-
-    @classmethod
-    def add_file_handler(cls, logfile_path: Union[str, Path],
-                         level: str = DEFAULT_LEVEL,
-                         _format: str = DEFAULT_FORMAT):
-        """
-        Create file handler.
-        This classmethod will allow setting custom file handler on children
-        Create stream handler
-        This classmethod will allow setting a custom stream handler on children
-
-        Parameters
-        ----------
         logfile_path: str or Path
-                      Path for writing out logfiles from logging
-                      default : False
-        level : str
-                logging level
-                default : 'INFO'
-        _format : str
-                  logging format
-                  default : '%(asctime)s - %(levelname)-8s - %(name)-12s: %(message)s'
+
+            A Python string or Path object to where the log files are
+            to be written.
+
+        level: str
+
+            A Python string specifying the logging level for the
+            respective Logger object.
+
+        _format: str
+
+            A Python string specifying the desired logging format.
 
         Returns
         -------
-        handler : logging.Handler
-                  file handler of a logging object
-        """
 
-        logfile_path = Path(logfile_path)
+        handler: logging.Handler
+
+            A Python logging.Handler object defining the file
+            handler for the logging object.
+
+        """
 
         # Create the directory containing the logfile_path
+        logfile_path = Path(logfile_path)
         if not logfile_path.parent.is_dir():
             logfile_path.mkdir(parents=True, exist_ok=True)
 
@@ -224,46 +378,151 @@ class Logger:
 
         return handler
 
+    @classmethod
+    def add_stream_handler(
+        cls: object, level: str, _format: str, colored_log: bool
+    ) -> logging.Handler:
+        """
+        Description
+        -----------
 
-def logit(logger, name=None, message=None):
+        This method creates a stream handler to allow the
+        specification of custom stream handlers for caller modules.
+
+        Parameters
+        ----------
+
+        level: str
+
+            A Python string specifying the logging level for the
+            respective Logger object.
+
+        _format: str
+
+            A Python string specifying the desired logging format.
+
+        colored_log: bool
+
+            A Python boolean valued variable specifying whether to use the
+            color attributes, defined within in the `ColoredFormatter`
+            object, for the logging messages.
+
+        Returns
+        -------
+
+        handler: logging.Handler
+
+            A Python logging.Handler object defining the stream
+            handler for the logging object.
+
+        """
+
+        # Define the stream handler for the respective caller module.
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setLevel(level)
+        _format = (
+            ColoredFormatter(
+                _format) if colored_log else logging.Formatter(_format)
+        )
+        handler.setFormatter(_format)
+
+        return handler
+
+    def get_logger(self: object) -> object:
+        """
+        Description
+        -----------
+
+        This method returns the logging object.
+
+        Returns
+        -------
+
+        logger: object
+
+            A Python logging object.
+
+        """
+
+        return self._logger
+
+
+# ----
+
+
+def logit(logger: object, name: str = None, message: str = None) -> Callable:
     """
-    Logger decorator to add logging to a function.
-    Simply add:
-    @logit(logger) before any function
+    Description
+    -----------
+
+    This function provides a decorator to be used for adding logging
+    to a module, class, method, or function.
+
     Parameters
     ----------
-    logger  : Logger
-              Logger object
-    name    : str
-              Name of the module to be logged
-              default: __module__
-    message : str
-              Name of the function to be logged
-              default: __name__
+
+    logger: object
+
+        A Python defining the Python Logger object.
+
+    Keywords
+    --------
+
+    name: str, optional
+
+        A Python string defining the module to be logged; if NoneType
+        upon entry this value will default to the calling module
+        `__module__` attribute.  Name of the module to be logged
+
+    message: str, optional
+
+        A Python string the function to be logged; if NoneType upon
+        entry this value will default to the calling function
+        `__name__` attribute.
+
+    Returns
+    -------
+
+    decorate: Callable
+
+        The Python decorator containing the Python Logger attributes.
+
     """
 
+    # Definee the decorator function.
     def decorate(func):
 
+        # Define the logger attributes.
         log_name = name if name else func.__module__
         log_msg = message if message else log_name + "." + func.__name__
 
+        # Execute the logger for the calling module, class, and/or
+        # function; proceed accordingly.
         @wraps(func)
         def wrapper(*args, **kwargs):
 
-            passed_args = [repr(aa) for aa in args]
-            passed_kwargs = [f"{kk}={repr(vv)}" for kk, vv in list(kwargs.items())]
+            # Collect (any) arguments and keyword arguments.
+            passed_args = [repr(arg) for arg in args]
+            passed_kwargs = [
+                f"{key}={repr(value)}" for (key, value) in list(kwargs.items())
+            ]
 
-            call_msg = 'BEGIN: ' + log_msg
-            logger.info(call_msg)
-            logger.debug(f"( {', '.join(passed_args + passed_kwargs)} )")
+            # Define the logger message string.
+            msg = f"BEGIN: {log_msg}"
+            logger.info(msg)
+            if logger.level == "DEBUG":
+                logger.debug(f"( {', '.join(passed_args + passed_kwargs)} )")
 
-            # Call the function
+            # Call the appropriate logger function.
             retval = func(*args, **kwargs)
 
-            # Close the logging with printing the return val
-            ret_msg = '  END: ' + log_msg
-            logger.info(ret_msg)
-            logger.debug(f" returning: {retval}")
+            # Define the logger message string, if the logging level
+            # is DEBUG, return the value returned by the logger
+            # function.
+            msg = f"END: {log_msg}"
+            logger.info(msg)
+            if logger.level == "DEBUG":
+                logger.debug(f"RETURNING: {retval}")
 
             return retval
 

--- a/ush/python/pygw/src/pygw/logger.py
+++ b/ush/python/pygw/src/pygw/logger.py
@@ -215,7 +215,7 @@ class Logger:
 
         # Define the base-class attributes.
         self.name = name
-        self.level = level
+        self.level = level.upper()
         self.format = _format
         self.colored_log = colored_log
 
@@ -223,8 +223,8 @@ class Logger:
         if level is None:
             level = os.environ.get("LOGGING_LEVEL")
 
-            if level is None:
-                level = Logger.DEFAULT_LEVEL
+        if level is None:
+            level = Logger.DEFAULT_LEVEL
 
         self.level = level.upper()
 


### PR DESCRIPTION
This PR contains the following and addressed issue #1438.

- The addition of a run-time environment query to allow module-dependent supported logging level (e.g., `CRITICAL`, `DEBUG`, `INFO`, `WARNING`);
- Documentation standardization as per the guidelines provided by the [PEP numpy documentation](https://numpydoc.readthedocs.io/en/latest/format.html).

**Description**

This PR provides task-level support for the respective `pygfs` applications. As an example, logging-level may be defined within `jobs/JGLOBAL_FORECAST` as follows.
```

#! /usr/bin/env bash

source "${HOMEgfs}/ush/preamble.sh"
source "${HOMEgfs}/ush/jjob_header.sh" -e "fcst" -c "base fcst"

export LOGGING_LEVEL="DEBUG"
```

This feature allows a user to change the logging level from the run-time environment rather than requiring modification of the respective `pygfs` module or task.

**Type of change**

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

**How Has This Been Tested?**

All `pygw/tests/test_logger.py` pass.
  
**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
